### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+tensorflow
+pandas
+numpy
+scipy
+astropy
+pydl
+absl-py


### PR DESCRIPTION
Simply install all the pip packages using `pip install -r requirements.txt`
Includes all the packages requirements for exoplanet-ml except Bazel.